### PR TITLE
Local build for docker 

### DIFF
--- a/KelBurgAPI/Dockerfile
+++ b/KelBurgAPI/Dockerfile
@@ -1,14 +1,15 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS base
 USER $APP_UID
 WORKDIR /app
-EXPOSE 8080
-EXPOSE 8081
+EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+
 COPY ["KelBurgAPI/KelBurgAPI.csproj", "KelBurgAPI/"]
 RUN dotnet restore "KelBurgAPI/KelBurgAPI.csproj"
+
 COPY . .
 WORKDIR "/src/KelBurgAPI"
 RUN dotnet build "KelBurgAPI.csproj" -c $BUILD_CONFIGURATION -o /app/build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,34 @@
 ﻿services:
-  kelburgapi:
-    image: kelburgapi
+  db:
+    image: postgres:15-alpine
+    container_name: kelburg_db
+    environment:
+      POSTGRES_USER: your_username
+      POSTGRES_PASSWORD: your_password
+      POSTGRES_DB: kelburgdb
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  app:
     build:
       context: .
       dockerfile: KelBurgAPI/Dockerfile
+    container_name: kelburg_api
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__DefaultConnection: "Host=db;Port=5432;Database=kelburgdb;Username=your_username;Password=your_password"
+    ports:
+      - "8080:8080"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  db_data:


### PR DESCRIPTION
**_TODO: make it run in the stack_**
This pull request includes changes to the Docker configuration for the `KelBurgAPI` project to use Alpine-based images and adds a PostgreSQL service to the Docker Compose setup. The most important changes include switching to Alpine images for the Dockerfile, exposing a different port, and adding a PostgreSQL service with health checks and environment variables.

### Dockerfile improvements:

* [`KelBurgAPI/Dockerfile`](diffhunk://#diff-d8f9db5e7e4117d58f54c39af1af3e064e18bb377bb91821ec7d6ab6d2d99386L1-R12): Switched the base and build images to Alpine versions (`mcr.microsoft.com/dotnet/aspnet:8.0-alpine` and `mcr.microsoft.com/dotnet/sdk:8.0-alpine`) for a smaller image size.
* [`KelBurgAPI/Dockerfile`](diffhunk://#diff-d8f9db5e7e4117d58f54c39af1af3e064e18bb377bb91821ec7d6ab6d2d99386L1-R12): Changed the exposed ports from 8080 and 8081 to port 80.

### Docker Compose enhancements:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L2-R34): Added a PostgreSQL service with the image `postgres:15-alpine`, including environment variables for user, password, and database configuration, as well as a health check and volume for data persistence.
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L2-R34): Updated the `kelburgapi` service to `app`, added environment variables for ASP.NET Core environment and connection strings, and specified a dependency on the PostgreSQL service with a health check condition.